### PR TITLE
Re-raise errors stemming from iteration

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,7 @@
 # Changelog
 
 ## Unreleased
+
+### Fixed
+
+* Errors raised while advancing an iterator are raised by `athreading.iterate`.

--- a/src/athreading/iterator.py
+++ b/src/athreading/iterator.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import functools
 import queue
 import sys
 import threading
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union, cast
 
 from athreading.aliases import AsyncIteratorContext
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
 _ParamsT = ParamSpec("_ParamsT")
 _YieldT = TypeVar("_YieldT")
+_T = TypeVar("_T")
 
 
 @overload
@@ -117,6 +119,12 @@ def _create_iterate_decorator(
     return decorator
 
 
+@dataclasses.dataclass
+class _Result(Generic[_T]):
+    value: _T | None
+    error: Exception | None
+
+
 class ThreadedAsyncIterator(AsyncIteratorContext[_YieldT]):
     """Wraps a synchronous iterator with an executor and exposes an AsyncIteratorContext."""
 
@@ -136,7 +144,7 @@ class ThreadedAsyncIterator(AsyncIteratorContext[_YieldT]):
         """
         self._yield_semaphore = asyncio.Semaphore(0)
         self._done_event = threading.Event()
-        self._queue: queue.Queue[_YieldT] = queue.Queue(buffer_maxsize or 0)
+        self._queue: queue.Queue[_Result[_YieldT]] = queue.Queue(buffer_maxsize or 0)
         self._iterator = iterator
         self._executor = executor
         self._worker_future: Optional[asyncio.Future[None]] = None
@@ -169,14 +177,18 @@ class ThreadedAsyncIterator(AsyncIteratorContext[_YieldT]):
         if not self._done_event.is_set() or not self._queue.empty():
             await self._yield_semaphore.acquire()
             if not self._queue.empty():
-                return self._queue.get(False)
+                result = self._queue.get(False)
+                if result.error is not None:
+                    raise result.error
+                else:
+                    return cast(_YieldT, result.value)
         raise StopAsyncIteration
 
     def __worker_threadsafe(self) -> None:
         """Stream the synchronous iterator to the queue and notify the async thread."""
         try:
             for item in self._iterator:
-                self._queue.put(item)
+                self._queue.put(_Result(value=item, error=None))
                 self._loop.call_soon_threadsafe(self._yield_semaphore.release)
 
                 while self._queue.full() and not self._done_event.is_set():
@@ -185,6 +197,9 @@ class ThreadedAsyncIterator(AsyncIteratorContext[_YieldT]):
 
                 if self._done_event.is_set():
                     break
+        except Exception as e:
+            self._queue.put(_Result(value=None, error=e))
+            self._loop.call_soon_threadsafe(self._yield_semaphore.release)
         finally:
             self._done_event.set()
             self._loop.call_soon_threadsafe(self._yield_semaphore.release)


### PR DESCRIPTION
No tests/docs yet, but it hopefully shows the shortcoming that needed fixing. I thought I could be more careful and try/catch `next(self._iterator)` more specifically, but it doesn't seem to be worth the effort -- I think _any_ exception needs to be re-raised anyway.